### PR TITLE
feat: add GitHub Actions workflow for generating top contributors lea…

### DIFF
--- a/.github/workflows/top-contributors.yml
+++ b/.github/workflows/top-contributors.yml
@@ -24,7 +24,6 @@ jobs:
           limit: 10
           marker_start: <!-- TOP-CONTRIBUTORS-START -->
           marker_end: <!-- TOP-CONTRIBUTORS-END -->
-          organization: frontend-knowledge-hub
           exclude: '["*[bot]"]'
 
       - name: Create Pull Request

--- a/.github/workflows/top-contributors.yml
+++ b/.github/workflows/top-contributors.yml
@@ -20,7 +20,7 @@ jobs:
         uses: ishakhorski/top-contributors@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          output: profile/README.md
+          output: README.md
           limit: 10
           marker_start: <!-- TOP-CONTRIBUTORS-START -->
           marker_end: <!-- TOP-CONTRIBUTORS-END -->

--- a/.github/workflows/top-contributors.yml
+++ b/.github/workflows/top-contributors.yml
@@ -1,0 +1,38 @@
+name: Generate Top Contributors Leaderboard
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 1'  # Every Monday at midnight UTC
+
+jobs:
+  generate-leaderboard:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Generate Top Contributors Leaderboard
+        uses: ishakhorski/top-contributors@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          output: profile/README.md
+          limit: 10
+          marker_start: <!-- TOP-CONTRIBUTORS-START -->
+          marker_end: <!-- TOP-CONTRIBUTORS-END -->
+          organization: frontend-knowledge-hub
+          exclude: '["*[bot]"]'
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "feat: Update top contributors leaderboard [auto]"
+          branch: feat/update-leaderboard
+          title: "feat: Weekly Top Contributors Update"
+          body: "This PR updates the README.md file with the latest top contributors."
+          author: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ Welcome to the **Vue Knowledge HUB**, your go-to repository for all things Vue.j
 2. **Contribute Your Knowledge**: Found something useful? Share it with the community!
 3. **Join Discussions**: Use Issues and Discussions to ask questions or propose new content.
 
+
+## 🏆 Top Contributors
+
+<!-- TOP-CONTRIBUTORS-START -->
+<!-- TOP-CONTRIBUTORS-END -->
+
 ## 🤝 How to Contribute
 
 We welcome contributions from everyone! Here's how you can help:


### PR DESCRIPTION
## Description
This pull request introduces a new workflow for generating a top contributors leaderboard and updates the `README.md` file to include a section for displaying the leaderboard. The most important changes include the addition of a GitHub Actions workflow and modifications to the `README.md` file.

## Checklist
- [x] My changes are aligned with the repository structure.
- [x] I have added necessary documentation/comments.
- [x] My code is tested and functional.

## Related Issues
Link to any relevant issues (e.g., `Fixes #123`).

## Notes
New workflow:
* [`.github/workflows/top-contributors.yml`](diffhunk://#diff-470bcb0c0ee31985111101ea7ea51f19730ae8d365af3f76c03df794e2d8ff50R1-R38): Added a new GitHub Actions workflow to generate a top contributors leaderboard every Monday at midnight UTC. This workflow checks out the repository, generates the leaderboard using the `ishakhorski/top-contributors` action, and creates a pull request to update the `README.md` file with the latest top contributors.